### PR TITLE
Update stopwords to include http and https

### DIFF
--- a/generate_wordcloud.py
+++ b/generate_wordcloud.py
@@ -5,8 +5,12 @@ Minimal Example
 Generating a square wordcloud from the US constitution using default arguments.
 """
 
-from wordcloud import WordCloud
+from wordcloud import WordCloud, STOPWORDS
+
+stopwords = set(STOPWORDS)
+stopwords.add("http")
+stopwords.add("https")
 
 def generate_wordcloud(text):
-	cloud = WordCloud(max_font_size=40).generate(text)
+	cloud = WordCloud(max_font_size=40, stopwords=stopwords).generate(text)
 	return cloud


### PR DESCRIPTION
Saw this getting used in some of the channels and it always had https in the word cloud haha.

I tested this locally with a test discord channel I made and it's working as expected.