### PR TITLE
Return statement to bypass channel creation

### DIFF
--- a/functions/detect_new_ep.py
+++ b/functions/detect_new_ep.py
@@ -7,6 +7,7 @@ darkhorse_podcast_category_id = 833086830521483324
 
 async def detect_new_ep(message: Message, client: Client):
 	if message.author.id == monitoRSS_id: # check if MonitoRSS posted a new livestream episode
+		return None # never execute the below code creating new channels. This line can be removed to restore channel creation functionality.
 		match = re.match(r".*Bret and Heather (.*) DarkHorse Podcast Livestream.*(https\:\/\/odysee\.com\/.*)", message.content, re.S)
 		print("MATCH: " + match[0])
 		if match:


### PR DESCRIPTION
I've added a `return` statement to line 10 which _should_ prevent the latter could from executing.

This is in service to the request: https://discord.com/channels/726864220838297610/1026521663082340362/1031341750138175538